### PR TITLE
Making the colon optional for HH:MM in _get_datetime regex

### DIFF
--- a/bennettbot/bot.py
+++ b/bennettbot/bot.py
@@ -522,7 +522,7 @@ def handle_schedule_suppression(message, say, slack_config, _is_im):
 
     if start_at is None or end_at is None or start_at >= end_at:
         say(
-            "[start_at] and [end_at] must be HH:MM with [start_at] < [end_at]",
+            "Wrong time format - `[start_at]` and `[end_at]` must be HH:MM with `[start_at]` < `[end_at]`",
             thread_ts=message.get("thread_ts"),
         )
         return
@@ -604,7 +604,10 @@ def handle_help(message, say, config, include_apology):
 def _get_datetime(hhmm):
     match = re.match(r"^(\d\d):(\d\d)$", hhmm)
     if not match:
-        return
+        # Maybe they just missed the colon?
+        match = re.match(r"^(\d\d)(\d\d)$", hhmm)
+        if not match:
+            return
 
     h = int(match.groups()[0])
     if not 0 <= h < 24:

--- a/bennettbot/bot.py
+++ b/bennettbot/bot.py
@@ -602,12 +602,9 @@ def handle_help(message, say, config, include_apology):
 
 
 def _get_datetime(hhmm):
-    match = re.match(r"^(\d\d):(\d\d)$", hhmm)
+    match = re.match(r"^(\d\d):?(\d\d)$", hhmm)
     if not match:
-        # Maybe they just missed the colon?
-        match = re.match(r"^(\d\d)(\d\d)$", hhmm)
-        if not match:
-            return
+        return
 
     h = int(match.groups()[0])
     if not 0 <= h < 24:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -105,8 +105,15 @@ def test_cancel_job(mock_app):
     assert not scheduler.get_jobs_of_type("test_good_job")
 
 
-def test_schedule_suppression(mock_app):
-    handle_message(mock_app, "<@U1234> test suppress job from 11:20 to 11:30")
+@pytest.mark.parametrize(
+    "message_text",
+    [
+        "<@U1234> test suppress job from 11:20 to 11:30",
+        "<@U1234> test suppress job from 1120 to 1130",
+    ],
+)
+def test_schedule_suppression(mock_app, message_text):
+    handle_message(mock_app, message_text)
 
     ss = scheduler.get_suppressions()
     assert len(ss) == 1
@@ -138,7 +145,7 @@ def test_schedule_suppression(mock_app):
 def test_schedule_suppression_with_bad_times(mock_app, message_text):
     handle_message(mock_app, message_text)
     assert_slack_client_sends_messages(
-        messages_kwargs=[{"channel": "channel", "text": "[start_at] and [end_at]"}],
+        messages_kwargs=[{"channel": "channel", "text": "`[start_at]` and `[end_at]`"}],
     )
     assert not scheduler.get_suppressions()
     # info message sent
@@ -147,7 +154,7 @@ def test_schedule_suppression_with_bad_times(mock_app, message_text):
         messages_kwargs=[
             {
                 "channel": "channel",
-                "text": "[start_at] and [end_at] must be HH:MM with [start_at] < [end_at]",
+                "text": "Wrong time format - `[start_at]` and `[end_at]` must be HH:MM with `[start_at]` < `[end_at]`",
             }
         ],
     )


### PR DESCRIPTION
Fixes #35.
- The colon in HH:MM is now optional.
- The error Slack message now says "Wrong time format - `[start_at]` and `[end_at]` must be HH:MM with `[start_at]` > `[end_at]`" so that it's clearer to the user what went wrong.
- Technically the "must" in the above sentence is now a lie, but there is probably no harm since the above wording is clearer than saying something like "HH:MM or HHMM".