### PR TITLE
Create "show all" command

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -302,21 +302,27 @@ raw_config = {
     "workflows": {
         "description": "Report GitHub Actions workflow runs",
         "jobs": {
-            "show": {
-                "run_args_template": "python jobs.py --target {target}",
+            "show_all": {
+                "run_args_template": "python jobs.py --target all",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
-            "show_actions": {
-                "run_args_template": "python jobs.py --target {repo} --detailed",
+            "show": {
+                "run_args_template": "python jobs.py --target {target}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
         },
         "slack": [
             {
+                "command": "show all",
+                "help": "Summarise GitHub Actions workflow runs for repos in all three organisations.",
+                "action": "schedule_job",
+                "job_type": "show_all",
+            },
+            {
                 "command": "show [target]",
-                # There is a line break in this help message because it's too long and this is the only action in the workspace so it doesn't look ugly anyway.
+                # There is a line break in this help message because it will take two lines anyway and breaking here gives better readability.
                 "help": "Summarise GitHub Actions workflow runs for a given `target` organisation or repo, provided in the form of `org` or `org/repo`. \n(Note: `org` is limited to the following shorthands and their full names: `os (opensafely)`, `osc (opensafely-core)`, `ebm (ebmdatalab)`.)",
                 "action": "schedule_job",
                 "job_type": "show",

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -211,7 +211,7 @@ def test_main_for_organisation(mock_workflows, mock_conclusions):
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": "Workflows for opensafely-core",
+                "text": "Workflows for opensafely-core repos",
             },
         },
         {
@@ -226,6 +226,55 @@ def test_main_for_organisation(mock_workflows, mock_conclusions):
             "text": {
                 "type": "mrkdwn",
                 "text": f"opensafely-core/airlock: {emoji*5} (<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|link>)",
+            },
+        },
+    ]
+
+
+@patch("workspace.workflows.jobs.RepoWorkflowReporter.get_latest_conclusions")
+@patch("workspace.workflows.jobs.RepoWorkflowReporter.get_workflows")
+@patch(
+    "workspace.workflows.config.REPOS",
+    {
+        "opensafely-core": ["airlock"],
+        "opensafely": ["documentation"],
+    },
+)
+def test_main_for_all_orgs(mock_workflows, mock_conclusions):
+    # Call main with org="all" and repo=None
+    # Use same workflows and conclusions for convenience
+    mock_workflows.return_value = WORKFLOWS_MAIN
+    conclusion = "success"
+    emoji = ":large_green_circle:"
+    mock_conclusions.return_value = {key: conclusion for key in WORKFLOWS_MAIN.keys()}
+    blocks = json.loads(jobs.main("all", repo=None, branch="main"))
+    assert blocks == [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Workflows for key repos",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":large_green_circle:=Success / :large_yellow_circle:=Running / :red_circle:=Failure / :white_circle:=Skipped / :heavy_multiplication_x:=Cancelled / :grey_question:=Other",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"opensafely-core/airlock: {emoji*5} (<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|link>)",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"opensafely/documentation: {emoji*5} (<https://github.com/opensafely/documentation/actions?query=branch%3Amain|link>)",
             },
         },
     ]

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -132,12 +132,12 @@ def test_get_conclusion_for_run(run, conclusion):
     ],
 )
 @patch("workspace.workflows.jobs.RepoWorkflowReporter.get_latest_conclusions")
-def test_summarize_repo(mock_conclusions, mock_airlock_reporter, conclusion, emoji):
+def test_summarise_repo(mock_conclusions, mock_airlock_reporter, conclusion, emoji):
     mock_conclusions.return_value = {
         key: conclusion for key in sorted(WORKFLOWS_MAIN.keys())
     }
 
-    block = mock_airlock_reporter.summarize()
+    block = mock_airlock_reporter.summarise()
     assert block == {
         "type": "section",
         "text": {

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -51,11 +51,11 @@ class RepoWorkflowReporter:
         Retrieves and reports on the status of workflow runs in a specified repo.
 
         Creating an instance of this class will automatically call the GitHub API to get a list of workflow IDs and their names.
-        Subsequently calling report() or summarize() will call a different endpoint of the API to get the status and conclusion for the most recent run of each workflow.
+        Subsequently calling report() or summarise() will call a different endpoint of the API to get the status and conclusion for the most recent run of each workflow.
 
         The statuses of workflows are represented by emojis, as defined in the EMOJI class attribute.
         report() will return a full JSON message with blocks for each workflow;
-        summarize() will return a single block with a summary of all workflows, which can be concatenated with other summaries.
+        summarise() will return a single block with a summary of all workflows, which can be concatenated with other summaries.
 
         Parameters:
             org_name: str
@@ -132,7 +132,7 @@ class RepoWorkflowReporter:
         ]
         return json.dumps(blocks)
 
-    def summarize(self) -> str:
+    def summarise(self) -> str:
         conclusions = self.get_latest_conclusions()
         emojis = "".join([self.get_emoji(c) for c in conclusions.values()])
         link = f"<{self.github_actions_link}|link>"
@@ -159,7 +159,7 @@ class RepoWorkflowReporter:
         warnings.warn(message=message, category=UserWarning)
 
 
-def summarize_all(branch):
+def summarise_all(branch):
     blocks = [
         get_header_block("Workflows for key repos"),
         get_text_block(RepoWorkflowReporter.EMOJI_KEY),
@@ -167,17 +167,17 @@ def summarize_all(branch):
     # Double for loop necessary since "org" and "repo" will both vary
     for org, repos in config.REPOS.items():
         for repo in repos:
-            blocks.append(RepoWorkflowReporter(org, repo, branch).summarize())
+            blocks.append(RepoWorkflowReporter(org, repo, branch).summarise())
     return json.dumps(blocks)
 
 
-def summarize_org(org, branch):
+def summarise_org(org, branch):
     blocks = [
         get_header_block(f"Workflows for {org} repos"),
         get_text_block(RepoWorkflowReporter.EMOJI_KEY),
     ]
     for repo in config.REPOS[org]:
-        blocks.append(RepoWorkflowReporter(org, repo, branch).summarize())
+        blocks.append(RepoWorkflowReporter(org, repo, branch).summarise())
     return json.dumps(blocks)
 
 
@@ -202,11 +202,11 @@ def parse_args():
 def main(org, repo, branch):
     if org == "all":
         # Summarise status for all repos in all orgs
-        return summarize_all(branch)
+        return summarise_all(branch)
     elif org in config.REPOS.keys():  # Valid organisation
         if repo is None:
             # Summarise status for multiple repos in an org
-            return summarize_org(org, branch)
+            return summarise_org(org, branch)
         # Single repo usage: Report status for all workflows in a specified repo
         return RepoWorkflowReporter(org, repo, branch).report()
     else:


### PR DESCRIPTION
- We want to create an automated slack reminder to show the emoji dashboard for repo workflows.
- It is better for that reminder to show all three organisations (opensafely, opensafely-core, ebmdatalab) in one dashboard instead of having to create three separate dashboards
- Added a "show all" command that shows the status of all repos listed in `config.py`