### PR TITLE
Strip link text when passing urls to Bennett Bot

### DIFF
--- a/bennettbot/bot.py
+++ b/bennettbot/bot.py
@@ -473,12 +473,12 @@ def handle_command(app, message, say, slack_config, is_im):
 
 
 def _remove_url_formatting(arg):
-    """Slack adds `<...>` around URLs. We want to pass them on without the
-    formatting.
+    """Slack formats URLs with angle brackets like <http://foo.com> or <http://foo.com|foo> (link text).
+    We want to pass URLs on without the formatting, and drop the text as the job will most likely only involve the URL.
 
     """
     if arg.startswith("<http") and arg.endswith(">"):
-        arg = arg[1:-1]
+        return arg[1:-1].split("|")[0]
     return arg
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -88,8 +88,16 @@ def test_schedule_python_job(mock_app):
     assert_job_matches(jj[0], "test_good_python_job", {}, "channel", T(0), None)
 
 
-def test_url_formatting_removed(mock_app):
-    handle_message(mock_app, "<@U1234> test do url <http://www.foo.com>")
+@pytest.mark.parametrize(
+    "message",
+    [
+        "<@U1234> test do url <http://www.foo.com>",
+        "<@U1234> test do url <http://www.foo.com|foo>",
+        "<@U1234> test do url <http://www.foo.com|http://www.foo.com>",
+    ],
+)
+def test_url_formatting_removed(mock_app, message):
+    handle_message(mock_app, message)
     jj = scheduler.get_jobs_of_type("test_job_with_url")
     assert len(jj) == 1
     assert_job_matches(


### PR DESCRIPTION
Fixes #58.

- Slack would often automatically identify URLs in commands to Bennett Bot and would format them as link text ( `<www.foo.com|www.foo.com>`)
- Alter the existing `_remove_url_formatting` function to correctly strip the link text when parsing the command and only pass the URL on.