### PR TITLE
Update list of skipped workflows and show missing workflows as ghost emojis

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -29,15 +29,38 @@ REPOS = {
         "opensafely.org",
         "team-manual",
         "metrics",
+        "bennettbot",
         "kissh",
     ],
 }
 
 SKIPPED_WORKFLOWS_ON_MAIN = {
-    "opensafely-core/airlock": [94122733],
-    "opensafely-core/job-runner": [26915902, 25002877, 26915901],
-    "opensafely-core/pipeline": [21951759],
-    "opensafely-core/python-docker": [21967294],
-    "opensafely-core/sqlrunner": [37329087],
-    "opensafely-core/cohort-extractor": [13520184],
+    "opensafely/documentation": [
+        65834242,  # [On workflow dispatch] Check docs with Vale
+    ],
+    "opensafely-core/airlock": [
+        94122733,  # [Ignored on main, PR#277] Docs
+    ],
+    "opensafely-core/job-runner": [
+        26915901,  # [On workflow call] Add software bill of materials to release (reusable)
+        26915902,  # [On workflow call] Scan with Grype (reusable)
+        25002877,  # [On PR] Dependency review
+        2393224,  #  [On PR] Tests, TODO: Remove this after Simon's merge
+    ],
+    "opensafely-core/pipeline": [
+        77090712,  # [Disabled] Pin pydantic
+    ],
+    "opensafely-core/python-docker": [
+        6866192,  # [On PR] Run tests
+        21967294,  # Dependabot auto-approve and enable auto-merge
+    ],
+    "opensafely-core/sqlrunner": [
+        37329087,  # Auto merge Dependabot PRs
+    ],
+    "opensafely-core/cohort-extractor": [
+        13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match
+    ],
+    "ebmdatalab/bennettbot": [
+        32719413,  #  Auto merge Dependabot PRs
+    ],
 }

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import os
-import warnings
 from urllib.parse import urljoin
 
 import requests
@@ -42,6 +41,7 @@ class RepoWorkflowReporter:
         "failure": ":red_circle:",
         "skipped": ":white_circle:",
         "cancelled": ":heavy_multiplication_x:",
+        "missing": ":ghost:",
         "other": ":grey_question:",
     }
     EMOJI_KEY = " / ".join([f"{v}={k.title()}" for k, v in EMOJI.items()])
@@ -96,15 +96,19 @@ class RepoWorkflowReporter:
             workflows.pop(workflow_id, None)
 
     def get_all_runs(self) -> list:
-        params = {"branch": self.branch} if self.branch else None
+        params = {"branch": self.branch} if self.branch else {}
+        params["per_page"] = 100
         return self._get_json_response("actions/runs", params=params)["workflow_runs"]
 
     def get_latest_conclusions(self) -> dict:
         all_runs = self.get_all_runs()
-        latest_runs = self.filter_for_latest_of_each_workflow(all_runs)
-        return {
+        latest_runs, missing_ids = self.find_latest_for_each_workflow(all_runs)
+        conclusions = {
             run["workflow_id"]: self.get_conclusion_for_run(run) for run in latest_runs
         }
+        missing = {workflow_id: "missing" for workflow_id in missing_ids}
+        conclusions.update(missing)
+        return conclusions
 
     @staticmethod
     def get_conclusion_for_run(run) -> str:
@@ -138,7 +142,7 @@ class RepoWorkflowReporter:
         link = f"<{self.github_actions_link}|link>"
         return get_text_block(f"{self.location}: {emojis} ({link})")
 
-    def filter_for_latest_of_each_workflow(self, all_runs) -> list:
+    def find_latest_for_each_workflow(self, all_runs) -> list:
         latest_runs = []
         found_ids = set()
         for run in all_runs:
@@ -147,16 +151,10 @@ class RepoWorkflowReporter:
             latest_runs.append(run)
             found_ids.add(run["workflow_id"])
             if found_ids == self.workflow_ids:
-                return latest_runs
-        # Some workflows were not found in the last ~1000 runs on this branch
-        self.warn_about_missing_workflows(found_ids)
-        return latest_runs
-
-    def warn_about_missing_workflows(self, found_ids):
+                return latest_runs, set()
+        # Some workflows were not found in the last ~50 runs on this branch
         missing_ids = self.workflow_ids - found_ids
-        missing = "\n".join([f"{i}={self.workflows[i]}" for i in missing_ids])
-        message = f"Missing IDs for {self.location}: \n{missing}."
-        warnings.warn(message=message, category=UserWarning)
+        return latest_runs, missing_ids
 
 
 def summarise_all(branch):


### PR DESCRIPTION
Fixes #586 .
- There is a dictionary of workflows that do not run on the main branch in `config.py` called `SKIPPED_WORKFLOWS_ON_MAIN`. This has now been updated with brief comments are now added to show what each ignored workflow is.
- There is one workflow marked with #TODO following [this conversation on Slack](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1727345417986209)
- Workflows that are not in `SKIPPED_WORKFLOWS_ON_MAIN` but are still missing now show up as ghost emojis. Previously these were printed to `stderr` as a warning. The current approach is better as it prompts the reader to review why the workflow was not found to be run on main. If there is a legitimate reason behind, the workflow ID can be added to `SKIPPED_WORKFLOWS_ON_MAIN`.

- As part of this PR, the number of workflows retrieved increased from 30 (default for GitHub's `per_page` parameter) to 100. As this will slow things down, it might be necessary to create a cache for the workflows to bring the number of workflows retrieved down again. Discussed in #597 .