### PR TITLE
Ignore tech-support keywords that only appear in a URL

### DIFF
--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -261,9 +262,12 @@ class MessageChecker:
             )
         )["messages"]["matches"]
         for message in messages:
-            if keyword not in message["text"]:
-                # Skip this message as it doesn't itself contain the magic keyword.
-                # It's likely to be a forwarded message or a copy/pasted link.
+            # remove any URLs from the message text; we don't want to match these
+            text = re.sub(r"<http.+>", "", message["text"])
+            if keyword not in text:
+                # Either the message contained the keyword in a URL only (and we've
+                # just removed it), or it didn't contain the keyword at all.
+                # The latter happens if it's a forwarded message or a copy/pasted link.
                 # The re-posted text appears in a search, but we only want to
                 # react to original messages.
                 continue

--- a/bennettbot/logger.py
+++ b/bennettbot/logger.py
@@ -1,11 +1,18 @@
 import functools
 import inspect
+import logging
+import os
 
 import structlog
 
 
 # Configure structlog to write to stdout without timstamps.
-structlog.configure(processors=[structlog.dev.ConsoleRenderer()])
+structlog.configure(
+    wrapper_class=structlog.make_filtering_bound_logger(
+        os.environ.get("LOG_LEVEL", logging.INFO)
+    ),
+    processors=[structlog.dev.ConsoleRenderer()],
+)
 logger = structlog.get_logger()
 
 


### PR DESCRIPTION
The standard bot matcher already does this, but the message checker was reposting messages that include tech-support only within a URL.

Also updates the logging config to log INFO and above in production. The constant debug log messages were making it hard to check logs to find out what it was and wasn't responding to.