### PR TITLE
Don't allow dependabot to upgrade httpretty

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    ignore:
+      # Keep httpretty pinned to <1.1.0
+      # See https://github.com/gabrielfalcao/HTTPretty/issues/425
+      - dependency-name: "httpretty"
+        update-types: ["version-update:semver-minor"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Due to a bug in httpretty v1.1.0, we need to keep it pinned. Stop dependabot trying to upgrade it.
See https://github.com/gabrielfalcao/HTTPretty/issues/425