### PR TITLE
Readability improvements for workflows dashboard

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -320,7 +320,7 @@ raw_config = {
         },
         "slack": [
             {
-                "command": "emoji",
+                "command": "key",
                 "help": "Show the emoji key being used in the workflow summaries.",
                 "action": "schedule_job",
                 "job_type": "display_emoji_key",

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -302,6 +302,11 @@ raw_config = {
     "workflows": {
         "description": "Report GitHub Actions workflow runs",
         "jobs": {
+            "display_emoji_key": {
+                "run_args_template": "python jobs.py --key",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
             "show_all": {
                 "run_args_template": "python jobs.py --target all",
                 "report_stdout": True,
@@ -314,6 +319,12 @@ raw_config = {
             },
         },
         "slack": [
+            {
+                "command": "emoji",
+                "help": "Show the emoji key being used in the workflow summaries.",
+                "action": "schedule_job",
+                "job_type": "display_emoji_key",
+            },
             {
                 "command": "show all",
                 "help": "Summarise GitHub Actions workflow runs for repos in all three organisations.",

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -290,7 +290,7 @@ def test_summarise_repo(
         "type": "section",
         "text": {
             "type": "mrkdwn",
-            "text": f"opensafely-core/airlock: {emoji*5} (<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|link>)",
+            "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {emoji*5}",
         },
     }
 
@@ -368,7 +368,7 @@ def test_main_for_organisation(mock_workflows, mock_conclusions, cache_path):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"opensafely-core/airlock: {emoji*5} (<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|link>)",
+                "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {emoji*5}",
             },
         },
     ]
@@ -404,14 +404,14 @@ def test_main_for_all_orgs(mock_workflows, mock_conclusions, cache_path):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"opensafely-core/airlock: {emoji*5} (<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|link>)",
+                "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {emoji*5}",
             },
         },
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"opensafely/documentation: {emoji*5} (<https://github.com/opensafely/documentation/actions?query=branch%3Amain|link>)",
+                "text": f"<https://github.com/opensafely/documentation/actions?query=branch%3Amain|opensafely/documentation>: {emoji*5}",
             },
         },
     ]

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -57,10 +57,85 @@ def mock_airlock_reporter():
     httpretty.reset()
 
 
+@patch("workspace.workflows.jobs._get_command_line_args")
+def test_parse_key_argument(args):
+    args.return_value = {"key": True}
+    assert jobs.parse_args() is None
+
+
+def test_print_key():
+    blocks = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Workflow status emoji key",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":large_green_circle:=Success",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":large_yellow_circle:=Running",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":red_circle:=Failure",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":white_circle:=Skipped",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":heavy_multiplication_x:=Cancelled",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":ghost:=Missing",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":grey_question:=Other",
+            },
+        },
+    ]
+    assert json.loads(jobs.get_text_blocks_for_key()) == blocks
+
+
+@patch("workspace.workflows.jobs._get_command_line_args")
+def test_no_target(args):
+    args.return_value = {"key": False}
+    with pytest.raises(ValueError):
+        jobs.parse_args()
+
+
 @pytest.mark.parametrize("org", ["opensafely-core", "osc"])
 @patch("workspace.workflows.jobs._get_command_line_args")
 def test_org_as_target(args, org):
-    args.return_value = {"target": org}
+    args.return_value = {"target": org, "key": False}
     parsed = jobs.parse_args()
     assert parsed == {"org": "opensafely-core", "repo": None}
 
@@ -68,14 +143,14 @@ def test_org_as_target(args, org):
 @pytest.mark.parametrize("org", ["opensafely-core", "osc"])
 @patch("workspace.workflows.jobs._get_command_line_args")
 def test_repo_as_target(args, org):
-    args.return_value = {"target": f"{org}/airlock"}
+    args.return_value = {"target": f"{org}/airlock", "key": False}
     parsed = jobs.parse_args()
     assert parsed == {"org": "opensafely-core", "repo": "airlock"}
 
 
 @patch("workspace.workflows.jobs._get_command_line_args")
 def test_invalid_target(args):
-    args.return_value = {"target": "some/invalid/input"}
+    args.return_value = {"target": "some/invalid/input", "key": False}
     with pytest.raises(ValueError):
         jobs.parse_args()
 
@@ -293,13 +368,6 @@ def test_main_for_organisation(mock_workflows, mock_conclusions, cache_path):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":large_green_circle:=Success / :large_yellow_circle:=Running / :red_circle:=Failure / :white_circle:=Skipped / :heavy_multiplication_x:=Cancelled / :ghost:=Missing / :grey_question:=Other",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
                 "text": f"opensafely-core/airlock: {emoji*5} (<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|link>)",
             },
         },
@@ -330,13 +398,6 @@ def test_main_for_all_orgs(mock_workflows, mock_conclusions, cache_path):
             "text": {
                 "type": "plain_text",
                 "text": "Workflows for key repos",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": ":large_green_circle:=Success / :large_yellow_circle:=Running / :red_circle:=Failure / :white_circle:=Skipped / :heavy_multiplication_x:=Cancelled / :ghost:=Missing / :grey_question:=Other",
             },
         },
         {

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -189,8 +189,7 @@ class RepoWorkflowReporter:
         conclusions = self.get_latest_conclusions()
         self.update_cache_file()
         emojis = "".join([self.get_emoji(c) for c in conclusions.values()])
-        link = f"<{self.github_actions_link}|link>"
-        return get_text_block(f"{self.location}: {emojis} ({link})")
+        return get_text_block(f"<{self.github_actions_link}|{self.location}>: {emojis}")
 
     def find_latest_for_each_workflow(self, all_runs) -> list:
         latest_runs = []


### PR DESCRIPTION
- The emoji key for the workflows dashboard takes up space and probably does not need to be shown daily. Hide it from the daily report and define a separate job to show the key.
- Users can now click the repo name to jump to the GitHub actions page in the browser instead of the "(link)" text after the emojis. This makes the report look less cluttered. 