### PR TITLE
More updates to the message checker

### DIFF
--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -250,7 +250,9 @@ class MessageChecker:
         messages = self.user_slack_client.search_messages(
             query=(
                 # Search for messages with the keyword but without the expected reaction
-                f"{keyword} -has::{reaction}: "
+                # Wrap the keyword in double quotes so we don't return "tech support" as
+                # well as "tech-support"
+                f'"{keyword}" -has::{reaction}: '
                 # exclude messages in the channel itself
                 f"-in:#{channel} "
                 # exclude messages from the bot

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -614,7 +614,7 @@ def test_message_checker_matched_messages(keyword, support_channel, reaction):
     assert requests_by_path["/api/search.messages"] == [
         {
             "query": [
-                f"{keyword} -has::{reaction}: -in:#{support_channel} "
+                f'"{keyword}" -has::{reaction}: -in:#{support_channel} '
                 f"-from:@{settings.SLACK_APP_USERNAME} -is:dm "
                 "before:2024-03-04 after:2024-03-02"
             ]


### PR DESCRIPTION
It seems like slack's search sometimes takes a while to pick up certain messages.
E.g. [this message](https://bennettoxford.slack.com/archives/C31D62X5X/p1727814632973539) from Rich didn't get SOS'd when he posted it. When I tried searching slack (in the UI, not with the API) a few minutes after the message was posted, it wasn't returning it in the search results when I searched using the BennettBot message checker query. It only came up if I also explicitly put `from:@<rich>` into the query.

However, this morning the search UI (and the API) are returning that message. So, I think some messages slip through the cracks somehow, don't get sent to our slack bolt app, and also don't get returned in search results. But they do get picked up some time later. Rich's message was sent at 9:30pm, and the message checker was only checking messages from the same day, so it only had a couple of hours to get through. This PR makes it check for all of yesterday AND today, to give it more of a chance to find them.

Also drive-by fixes:
- no need to use a "before" parameter to search; "after" on its own will search up until now
- wrap the keyword in double quotes so we only find exactly "tech-support" (with hyphen)