### PR TITLE
Only show repos that have unsuccessful workflow runs in daily dashboards

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -332,13 +332,13 @@ raw_config = {
             },
             {
                 "command": "show all",
-                "help": "Summarise GitHub Actions workflow runs for repos in all three organisations.",
+                "help": "Summarise GitHub Actions workflow runs for repos in all organisations.",
                 "action": "schedule_job",
                 "job_type": "show_all",
             },
             {
                 "command": "show-failed",
-                "help": "Summarise GitHub Actions workflow runs for repos in all three organisations, skipping repos whose runs are all successful.",
+                "help": "Summarise GitHub Actions workflow runs for repos in all organisations, skipping repos whose runs are all successful.",
                 "action": "schedule_job",
                 "job_type": "show_failed",
             },

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -300,6 +300,7 @@ raw_config = {
         ]
     },
     "workflows": {
+        "restricted": True,
         "description": "Report GitHub Actions workflow runs",
         "jobs": {
             "display_emoji_key": {

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -312,6 +312,11 @@ raw_config = {
                 "report_stdout": True,
                 "report_format": "blocks",
             },
+            "show_failed": {
+                "run_args_template": "python jobs.py --target all --skip-successful",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
             "show": {
                 "run_args_template": "python jobs.py --target {target}",
                 "report_stdout": True,
@@ -330,6 +335,12 @@ raw_config = {
                 "help": "Summarise GitHub Actions workflow runs for repos in all three organisations.",
                 "action": "schedule_job",
                 "job_type": "show_all",
+            },
+            {
+                "command": "show-failed",
+                "help": "Summarise GitHub Actions workflow runs for repos in all three organisations, skipping repos whose runs are all successful.",
+                "action": "schedule_job",
+                "job_type": "show_failed",
             },
             {
                 "command": "show [target]",

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -232,7 +232,7 @@ def test_cache_creation(mock_write, mock_airlock_reporter, freezer):
     mock_write.return_value = None  # Disable writing to file and test separately
     assert mock_airlock_reporter.cache == {}
     freezer.move_to("2023-09-30 09:00:08")
-    _ = mock_airlock_reporter.get_latest_conclusions()
+    mock_airlock_reporter.get_latest_conclusions()
     assert mock_airlock_reporter.cache == CACHE["opensafely-core/airlock"]
 
 
@@ -266,7 +266,7 @@ def test_get_conclusion_for_run(run, conclusion):
     ],
 )
 def test_get_summary_block(conclusion, emoji):
-    conclusions = [conclusion for _ in range(5)]
+    conclusions = [conclusion] * 5
     block = jobs.get_summary_block("opensafely-core/airlock", conclusions)
     assert block == {
         "type": "section",

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -50,7 +50,7 @@ def mock_airlock_reporter():
         body=Path("tests/workspace/runs.json").read_text(),
         match_querystring=False,  # Test the querystring separately
     )
-    reporter = jobs.RepoWorkflowReporter("opensafely-core", "airlock")
+    reporter = jobs.RepoWorkflowReporter("opensafely-core/airlock")
     reporter.cache = {}  # Drop the cache and test _load_cache_for_repo separately
     yield reporter
     httpretty.disable()
@@ -164,7 +164,7 @@ def test_get_workflows():
         match_querystring=True,
         body=Path("tests/workspace/workflows.json").read_text(),
     )
-    reporter = jobs.RepoWorkflowReporter("opensafely-core", "airlock")
+    reporter = jobs.RepoWorkflowReporter("opensafely-core/airlock")
     assert len(reporter.workflows) == 5
     assert reporter.workflows == WORKFLOWS_MAIN
 

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -116,7 +116,7 @@ class RepoWorkflowReporter:
     def get_latest_conclusions(self) -> dict:
         """
         Use the GitHub API to get the conclusion of the most recent run for each workflow.
-        Update the cache with the conclusions and the timestamp of the retrieval.
+        Update the cache file with the conclusions and the timestamp of the retrieval.
         """
         # Use the moment just before calling the GitHub API as the timestamp
         timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -133,6 +133,7 @@ class RepoWorkflowReporter:
             # To be consistent with the JSON file which has the IDs as strings
             "conclusions": {str(k): v for k, v in conclusions.items()},
         }
+        self.write_cache_to_file()
         return conclusions
 
     @staticmethod
@@ -154,7 +155,7 @@ class RepoWorkflowReporter:
             conclusions[workflow_id] = previous_conclusions.get(id_str, "missing")
         return
 
-    def update_cache_file(self):
+    def write_cache_to_file(self):
         cache_file_contents = load_cache()
         cache_file_contents[self.location] = self.cache
         with open(CACHE_PATH, "w") as f:
@@ -167,7 +168,6 @@ class RepoWorkflowReporter:
             return f"{name}: {emoji} {conclusion.title().replace('_', ' ')}"
 
         conclusions = self.get_latest_conclusions()
-        self.update_cache_file()
         link = get_github_actions_link(self.location)
         lines = [format_text(wf, conclusion) for wf, conclusion in conclusions.items()]
         blocks = [
@@ -179,7 +179,6 @@ class RepoWorkflowReporter:
 
     def summarise(self) -> str:
         conclusions = self.get_latest_conclusions()
-        self.update_cache_file()
         link = get_github_actions_link(self.location)
         emojis = "".join([get_emoji(c) for c in conclusions.values()])
         return get_text_block(f"<{link}|{self.location}>: {emojis}")


### PR DESCRIPTION
Mainly fixes #603 but there are additional changes.
- Added a `show-failed` job that gives a dashboard where the repos with all-green status are not shown. This is expected to be the main dashboard shown daily in the tech channel. (see comment in #603)
- Repos in the summary dashboard generated by `show all` are presented in ascending order of their success rate. Essentially this puts the repos with unsuccessful workflow runs at the top of the dashboard and prevents them from being truncated in the Slack message.
- After discussion with @rebkwok, there is little need to report workflow run statuses for any branch other than `main`, so the functionality to retrieve/cache other branches is removed. This simplifies the code and the tests.
- Additional structural changes to the code accompany the above changes:
  - Remove `summarise()` as a class method and move the functionality to create summary reports outside the class
  - `update_cache_file` is renamed `write_cache_to_file` and is no longer called on its own (except in tests). It is called at the end of `get_latest_conclusions`. Now, there isn't really a scenario where we would fetch results from the GitHub API and not want to cache it.

Apologies for loads of changes, hope the commit splitting makes sense!

Notes on why the `show-failed` command is not called `show failed`: 
- Essentially the `show all` command and the `show [target]` command is one command disguised into two. `show all` is just a special case of `show [target]`
- `show-failed` is a different command that uses a different command line flag. It should really be `show-failed all` but the `all` is kind of implied and is skipped so that people don't have to type it every time.