### PR TITLE
Section the "show all"/"show-failed" reports by team

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -304,22 +304,22 @@ raw_config = {
         "description": "Report GitHub Actions workflow runs",
         "jobs": {
             "display_emoji_key": {
-                "run_args_template": "python jobs.py --key",
+                "run_args_template": "python jobs.py key",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
             "show_all": {
-                "run_args_template": "python jobs.py --target all",
+                "run_args_template": "python jobs.py show --target all",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
             "show_failed": {
-                "run_args_template": "python jobs.py --target all --skip-successful",
+                "run_args_template": "python jobs.py show --target all --skip-successful",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
             "show": {
-                "run_args_template": "python jobs.py --target {target}",
+                "run_args_template": "python jobs.py show --target {target}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -330,7 +330,11 @@ def test_main_for_repo(mock_conclusions, conclusion, reported, emoji):
 @patch("workspace.workflows.jobs.RepoWorkflowReporter.get_runs_since_last_retrieval")
 @patch("workspace.workflows.jobs.RepoWorkflowReporter.get_workflows")
 @patch(
-    "workspace.workflows.config.REPOS", {"opensafely-core": ["airlock", "failing-repo"]}
+    "workspace.workflows.config.REPOS",
+    {
+        "airlock": {"org": "opensafely-core", "team": "Team RAP"},
+        "failing-repo": {"org": "opensafely-core", "team": "Team REX"},
+    },
 )
 def test_main_for_organisation(mock_workflows, mock_runs, cache_path):
     # Call main with a valid org and repo=None, with skip_successful=False
@@ -386,8 +390,8 @@ def test_main_for_organisation(mock_workflows, mock_runs, cache_path):
 @patch(
     "workspace.workflows.config.REPOS",
     {
-        "opensafely-core": ["airlock"],
-        "opensafely": ["documentation"],
+        "airlock": {"org": "opensafely-core", "team": "Team RAP"},
+        "documentation": {"org": "opensafely", "team": "Team REX"},
     },
 )
 def test_main_for_all_orgs(mock_workflows, mock_conclusions, cache_path):
@@ -404,14 +408,7 @@ def test_main_for_all_orgs(mock_workflows, mock_conclusions, cache_path):
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": "Workflows for key repos",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {emoji*5}",
+                "text": "Workflows for Team REX",
             },
         },
         {
@@ -421,6 +418,20 @@ def test_main_for_all_orgs(mock_workflows, mock_conclusions, cache_path):
                 "text": f"<https://github.com/opensafely/documentation/actions?query=branch%3Amain|opensafely/documentation>: {emoji*5}",
             },
         },
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Workflows for Team RAP",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {emoji*5}",
+            },
+        },
     ]
 
 
@@ -428,7 +439,10 @@ def test_main_for_all_orgs(mock_workflows, mock_conclusions, cache_path):
 @patch("workspace.workflows.jobs.RepoWorkflowReporter.get_workflows")
 @patch(
     "workspace.workflows.config.REPOS",
-    {"opensafely-core": ["airlock"], "opensafely": ["failing-repo"]},
+    {
+        "airlock": {"org": "opensafely-core", "team": "Team RAP"},
+        "failing-repo": {"org": "opensafely", "team": "Team REX"},
+    },
 )
 def test_main_for_all_skipping_successful(mock_workflows, mock_runs, cache_path):
     # Call main with a valid org and repo=None, with skip_successful=True
@@ -451,14 +465,14 @@ def test_main_for_all_skipping_successful(mock_workflows, mock_runs, cache_path)
         blocks = json.loads(jobs.main("all", repo=None, skip_successful=True))
     red = ":red_circle:"
     assert blocks == [
-        {
+        {  # Only the Team REX section containing the failing repo should appear
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": "Workflows for key repos",
+                "text": "Workflows for Team REX",
             },
         },
-        {  # Only the failing repo should appear
+        {
             "type": "section",
             "text": {
                 "type": "mrkdwn",

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -4,34 +4,101 @@ SHORTHANDS = {
     "ebm": "ebmdatalab",
 }
 
+TEAMS = [
+    "Tech shared",
+    "Team REX",
+    "Team RAP",
+]
+
 REPOS = {
-    "opensafely": [
-        "documentation",
-    ],
-    "opensafely-core": [
-        "job-server",
-        "job-runner",
-        "ehrql",
-        "airlock",
-        "opencodelists",
-        "pipeline",
-        "opensafely-cli",
-        "python-docker",
-        "backend-server",
-        "sqlrunner",
-        "cohort-extractor",
-        "actions-registry",
-        "reports",
-    ],
-    "ebmdatalab": [
-        "openprescribing",
-        "bennett.ox.ac.uk",
-        "opensafely.org",
-        "team-manual",
-        "metrics",
-        "bennettbot",
-        "kissh",
-    ],
+    "actions-registry": {
+        "org": "opensafely-core",
+        "team": "Team REX",
+    },
+    "airlock": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "backend-server": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "bennett.ox.ac.uk": {
+        "org": "ebmdatalab",
+        "team": "Team REX",
+    },
+    "bennettbot": {
+        "org": "ebmdatalab",
+        "team": "Team RAP",
+    },
+    "cohort-extractor": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "documentation": {
+        "org": "opensafely",
+        "team": "Tech shared",
+    },
+    "ehrql": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "job-runner": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "job-server": {
+        "org": "opensafely-core",
+        "team": "Team REX",
+    },
+    "kissh": {
+        "org": "ebmdatalab",
+        "team": "Team RAP",
+    },
+    "metrics": {
+        "org": "ebmdatalab",
+        "team": "Team REX",
+    },
+    "openprescribing": {
+        "org": "ebmdatalab",
+        "team": "Team RAP",
+    },
+    "opensafely-cli": {
+        "org": "opensafely-core",
+        "team": "Team REX",
+    },
+    "opensafely.org": {
+        "org": "ebmdatalab",
+        "team": "Team REX",
+    },
+    "opencodelists": {
+        "org": "opensafely-core",
+        "team": "Team REX",
+    },
+    "pipeline": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "python-docker": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "reports": {
+        "org": "opensafely-core",
+        "team": "Team REX",
+    },
+    "repo-template": {
+        "org": "opensafely-core",
+        "team": "Tech shared",
+    },
+    "sqlrunner": {
+        "org": "opensafely-core",
+        "team": "Team RAP",
+    },
+    "team-manual": {
+        "org": "ebmdatalab",
+        "team": "Team REX",
+    },
 }
 
 SKIPPED_WORKFLOWS_ON_MAIN = {


### PR DESCRIPTION
- The team associated for each repo is now hard-coded in the config
- The "show all" and "show-failed" jobs present the repos in sections for each team
- Following [this comment](https://github.com/ebmdatalab/bennettbot/pull/602#discussion_r1784331892), use subparsers for the command line arguments
- For reports on single repos, one can now type just the repo name instead of `org/repo` (e.g. `workflows show airlock` instead of `workflows show osc/airlock`). The `--help` message was not changed to avoid unnecessary confusion (as it is already very long). It might be a good idea to later define a `workflows targets` job that just prints guidance on valid values for `[target]` instead.