### PR TITLE
Do not write to the cache file if the run status is not final

### DIFF
--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -244,6 +244,17 @@ def test_write_to_cache_file(mock_airlock_reporter, cache_path):
     assert json.loads(cache_path.read_text()) == CACHE
 
 
+@pytest.mark.parametrize("conclusion", ["running", "queued"])
+@patch("workspace.workflows.jobs.RepoWorkflowReporter.get_conclusion_for_run")
+def test_pending_status_not_written_to_cache_file(
+    mock_get_conclusion_for_run, mock_airlock_reporter, cache_path, conclusion
+):
+    mock_get_conclusion_for_run.return_value = conclusion
+    with patch("workspace.workflows.jobs.CACHE_PATH", cache_path):
+        mock_airlock_reporter.get_latest_conclusions()
+    assert not cache_path.exists()
+
+
 @pytest.mark.parametrize(
     "run, conclusion",
     [

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -145,7 +145,10 @@ class RepoWorkflowReporter:
             # To be consistent with the JSON file which has the IDs as strings
             "conclusions": {str(k): v for k, v in conclusions.items()},
         }
-        self.write_cache_to_file()
+
+        pending = "running" in conclusions.values() or "queued" in conclusions.values()
+        if not pending:  # Only write cache to file if the status is final
+            self.write_cache_to_file()
         return conclusions
 
     @staticmethod


### PR DESCRIPTION
- Currently Bennett Bot caches the status of workflow runs after each call to the GitHub API along with the timestamp
- For workflow runs with "running" or "queued" status at the time of the API call, their status will be updated later down the line, but this is oblivious to Bennett Bot
- Skip cache-ing these pending statuses so that Bennett Bot will see these runs again in its next API call