### PR TITLE
Keep job-runner tests in ignored list

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -45,7 +45,7 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
         26915901,  # [On workflow call] Add software bill of materials to release (reusable)
         26915902,  # [On workflow call] Scan with Grype (reusable)
         25002877,  # [On PR] Dependency review
-        2393224,  #  [On PR] Tests, TODO: Remove this after Simon's merge
+        2393224,  #  [On PR] Tests
     ],
     "opensafely-core/pipeline": [
         77090712,  # [Disabled] Pin pydantic


### PR DESCRIPTION
- No change to code: removal of a TODO comment that arose from my misunderstanding of this [conversation](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1727346247812609?thread_ts=1727345417.986209&cid=C069YDR4NCA) 
- The workflow to publish the docker image is its separate GHA, so the Tests GHA still does not run on main and Bennett Bot should still skip trying to find it