### PR TITLE
Allow support channel settings to be either channel name OR channel ID

### DIFF
--- a/bennettbot/bot.py
+++ b/bennettbot/bot.py
@@ -111,7 +111,11 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
     support_config = {
         "tech-support": {
             "keyword": "tech-support",
-            "channel_id": channels[settings.SLACK_TECH_SUPPORT_CHANNEL],
+            # Get the channel ID by channel name. If it doesn't exist, assume the setting is
+            # already the channel ID
+            "channel_id": channels.get(
+                settings.SLACK_TECH_SUPPORT_CHANNEL, settings.SLACK_TECH_SUPPORT_CHANNEL
+            ),
             # Match "tech-support" as a word (treating hyphens as word characters), except if
             # it's preceded by a slash to avoid matching it in URLs
             "regex": re.compile(r".*(^|[^\w\-/])tech-support($|[^\w\-]).*", flags=re.I),
@@ -119,7 +123,12 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
         },
         "bennett-admins": {
             "keyword": "bennett-admins",
-            "channel_id": channels[settings.SLACK_BENNETT_ADMINS_CHANNEL],
+            # Get the channel ID by channel name. If it doesn't exist, assume the setting is
+            # already the channel ID
+            "channel_id": channels.get(
+                settings.SLACK_BENNETT_ADMINS_CHANNEL,
+                settings.SLACK_BENNETT_ADMINS_CHANNEL,
+            ),
             # Match "bennett-admins" or "bennet-admins" as a word (treating hyphens as
             # word characters), except if it's preceded by a slash to avoid matching it
             # in URLs
@@ -129,6 +138,12 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
             "reaction": ":flamingo:",
         },
     }
+    # Check that channel settings mapped to valid channel IDs
+    for support in support_config.values():
+        if support["channel_id"] not in channels.values():
+            raise ValueError(
+                f"{support['keyword']} channel id '{support['channel_id']}' not found"
+            )
 
     @app.event(
         "app_mention",

--- a/bennettbot/config.py
+++ b/bennettbot/config.py
@@ -1,0 +1,39 @@
+import re
+
+from . import settings
+
+
+def get_support_config(channels=None):
+    channels = channels or {}
+    return {
+        "tech-support": {
+            "keyword": "tech-support",
+            # Use the support setting to get the channel. We use channel ID if it is
+            # available, otherwise we default to using the setting value (on the
+            # assumption that the setting value is the channel name).
+            "support_channel": channels.get(
+                settings.SLACK_TECH_SUPPORT_CHANNEL, settings.SLACK_TECH_SUPPORT_CHANNEL
+            ),
+            # Match "tech-support" as a word (treating hyphens as word characters), except if
+            # it's preceded by a slash to avoid matching it in URLs
+            "regex": re.compile(r".*(^|[^\w\-/])tech-support($|[^\w\-]).*", flags=re.I),
+            "reaction": "sos",
+        },
+        "bennett-admins": {
+            "keyword": "bennett-admins",
+            # Use the support setting to get the channel. We use channel ID if it is
+            # available, otherwise we default to using the setting value (on the
+            # assumption that the setting value is the channel name).
+            "support_channel": channels.get(
+                settings.SLACK_BENNETT_ADMINS_CHANNEL,
+                settings.SLACK_BENNETT_ADMINS_CHANNEL,
+            ),
+            # Match "bennett-admins" or "bennet-admins" as a word (treating hyphens as
+            # word characters), except if it's preceded by a slash to avoid matching it
+            # in URLs
+            "regex": re.compile(
+                r".*(^|[^\w\-/])bennett?-admins($|[^\w\-]).*", flags=re.I
+            ),
+            "reaction": "flamingo",
+        },
+    }

--- a/bennettbot/config.py
+++ b/bennettbot/config.py
@@ -8,9 +8,9 @@ def get_support_config(channels=None):
     return {
         "tech-support": {
             "keyword": "tech-support",
-            # Use the support setting to get the channel. We use channel ID if it is
-            # available, otherwise we default to using the setting value (on the
-            # assumption that the setting value is the channel name).
+            # Use the support setting (a channel name or channel ID) to get the channel.
+            # We first attempt to retrieve channel ID from the channels dict (if provided),
+            # otherwise we default to using the setting value as is.
             "support_channel": channels.get(
                 settings.SLACK_TECH_SUPPORT_CHANNEL, settings.SLACK_TECH_SUPPORT_CHANNEL
             ),
@@ -21,9 +21,9 @@ def get_support_config(channels=None):
         },
         "bennett-admins": {
             "keyword": "bennett-admins",
-            # Use the support setting to get the channel. We use channel ID if it is
-            # available, otherwise we default to using the setting value (on the
-            # assumption that the setting value is the channel name).
+            # Use the support setting (a channel name or channel ID) to get the channel.
+            # We first attempt to retrieve channel ID from the channels dict (if provided),
+            # otherwise we default to using the setting value as is.
             "support_channel": channels.get(
                 settings.SLACK_BENNETT_ADMINS_CHANNEL,
                 settings.SLACK_BENNETT_ADMINS_CHANNEL,

--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import requests
 
 from . import job_configs, scheduler, settings
+from .config import get_support_config
 from .logger import logger
 from .slack import notify_slack, slack_web_client
 
@@ -211,16 +212,7 @@ class MessageChecker:
         self.bot_slack_client = bot_slack_client
         self.user_slack_client = user_slack_client
 
-        self.config = {
-            "tech-support": {
-                "reaction": "sos",
-                "channel": settings.SLACK_TECH_SUPPORT_CHANNEL,
-            },
-            "bennett-admins": {
-                "reaction": "flamingo",
-                "channel": settings.SLACK_BENNETT_ADMINS_CHANNEL,
-            },
-        }
+        self.config = get_support_config()
 
     def run_check(self):  # pragma: no cover
         """Start running the check in a new subprocess."""
@@ -248,7 +240,7 @@ class MessageChecker:
     def check_messages(self, keyword, after):
         logger.debug("Checking %s messages", keyword)
         reaction = self.config[keyword]["reaction"]
-        channel = self.config[keyword]["channel"]
+        channel = self.config[keyword]["support_channel"]
         messages = self.user_slack_client.search_messages(
             query=(
                 # Search for messages with the keyword but without the expected reaction

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -524,21 +524,6 @@ def build_log_dir(job_type_with_namespace):
     )
 
 
-def test_message_checker_config():
-    checker = MessageChecker(slack_web_client("bot"), slack_web_client("user"))
-    # channel IDs are retrieved from mock_web_api_server
-    assert checker.config == {
-        "tech-support": {
-            "reaction": "sos",
-            "channel": settings.SLACK_TECH_SUPPORT_CHANNEL,
-        },
-        "bennett-admins": {
-            "reaction": "flamingo",
-            "channel": settings.SLACK_BENNETT_ADMINS_CHANNEL,
-        },
-    }
-
-
 def test_message_checker_run(freezer):
     freezer.move_to("2024-10-08 23:30")
     httpretty_register(


### PR DESCRIPTION
The bennett admins channel name was recently changed, which required a change to the production environment variable, because our settings used channel names and not channel ids. There are benefits to being able to use both. 

Most slack functions will accept either a channel name or a channel ID. We always use a channel ID for support channels for the few functions that require it. For readability, our settings have used channel names, but the disadvantage is that if a channel name changes, bennettbot will no longer be able to post to it.

This allows settings to be either channel name or channel ID. If we decide to change them to channel IDs in prod, this means channel names can be changed with no interruption to how the support keywords work. 

Most of the changes in this PR are actually just some refactoring of how the support channel config is set up.