### PR TITLE
Ignore current-expected workflow failures

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -108,6 +108,9 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     "opensafely-core/airlock": [
         94122733,  # [Ignored on main, PR#277] Docs
     ],
+    "opensafely-core/cohort-extractor": [
+        13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match
+    ],
     "opensafely-core/job-runner": [
         26915901,  # [On workflow call] Add software bill of materials to release (reusable)
         26915902,  # [On workflow call] Scan with Grype (reusable)
@@ -123,9 +126,6 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     ],
     "opensafely-core/sqlrunner": [
         37329087,  # Auto merge Dependabot PRs
-    ],
-    "opensafely-core/cohort-extractor": [
-        13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match
     ],
     "ebmdatalab/bennettbot": [
         32719413,  # Auto merge Dependabot PRs

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -125,7 +125,11 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
         6866192,  # [On PR] Run tests
         21967294,  # Dependabot auto-approve and enable auto-merge
     ],
+    "opensafely-core/repo-template": [
+        108662507,  # Dependabot updates (currently broken and expected to be replaced)
+    ],
     "opensafely-core/sqlrunner": [
+        108481072,  # Dependabot updates (currently broken and expected to be replaced)
         37329087,  # Auto merge Dependabot PRs
     ],
     "ebmdatalab/bennettbot": [

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -130,7 +130,6 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     ],
     "opensafely-core/sqlrunner": [
         108481072,  # Dependabot updates (currently broken and expected to be replaced)
-        37329087,  # Auto merge Dependabot PRs
     ],
     "ebmdatalab/bennettbot": [
         32719413,  # Auto merge Dependabot PRs

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -112,7 +112,7 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
         26915901,  # [On workflow call] Add software bill of materials to release (reusable)
         26915902,  # [On workflow call] Scan with Grype (reusable)
         25002877,  # [On PR] Dependency review
-        2393224,  #  [On PR] Tests
+        2393224,  # [On PR] Tests
     ],
     "opensafely-core/pipeline": [
         77090712,  # [Disabled] Pin pydantic
@@ -128,6 +128,6 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
         13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match
     ],
     "ebmdatalab/bennettbot": [
-        32719413,  #  Auto merge Dependabot PRs
+        32719413,  # Auto merge Dependabot PRs
     ],
 }

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -104,6 +104,7 @@ REPOS = {
 SKIPPED_WORKFLOWS_ON_MAIN = {
     "opensafely/documentation": [
         65834242,  # [On workflow dispatch] Check docs with Vale
+        25878886,  # Check links (expected to break, notifications handled elsewhere)
     ],
     "opensafely-core/airlock": [
         94122733,  # [Ignored on main, PR#277] Docs
@@ -129,5 +130,14 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     ],
     "ebmdatalab/bennettbot": [
         32719413,  # Auto merge Dependabot PRs
+    ],
+    "ebmdatalab/bennett.ox.ac.uk": [
+        42498719,  # Check links (expected to break, notifications handled elsewhere)
+    ],
+    "ebmdatalab/opensafely.org": [
+        26433647,  # Check links (expected to break, notifications handled elsewhere)
+    ],
+    "ebmdatalab/team-manual": [
+        31178226,  # Check links (expected to break, notifications handled elsewhere)
     ],
 }


### PR DESCRIPTION
I haven't tested this locally as I wasn't immediately able to successfully follow the instructions in the DEVELOPERS file. I'm very happy to do so if you want to spend some time showing me how to do it -- or since it's non-disruptive to get this wrong, we can merge and I'll test in prod.