### PR TITLE
Hide currently known failures from the summary dashboards

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -108,6 +108,9 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     "opensafely-core/airlock": [
         94122733,  # [Ignored on main, PR#277] Docs
     ],
+    "opensafely-core/cohort-extractor": [
+        13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match
+    ],
     "opensafely-core/job-runner": [
         26915901,  # [On workflow call] Add software bill of materials to release (reusable)
         26915902,  # [On workflow call] Scan with Grype (reusable)
@@ -123,9 +126,6 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     ],
     "opensafely-core/sqlrunner": [
         37329087,  # Auto merge Dependabot PRs
-    ],
-    "opensafely-core/cohort-extractor": [
-        13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match
     ],
     "ebmdatalab/bennettbot": [
         32719413,  # Auto merge Dependabot PRs

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -122,13 +122,13 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     ],
     "opensafely-core/python-docker": [
         6866192,  # [On PR] Run tests
-        21967294,  # Dependabot auto-approve and enable auto-merge
+        21967294,  # [On PR] Dependabot auto-approve and enable auto-merge
     ],
     "opensafely-core/sqlrunner": [
-        37329087,  # Auto merge Dependabot PRs
+        37329087,  # [On PR] Auto merge Dependabot PRs
     ],
     "ebmdatalab/bennettbot": [
-        32719413,  # Auto merge Dependabot PRs
+        32719413,  # [On PR] Auto merge Dependabot PRs
     ],
 }
 

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -112,7 +112,7 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
         26915901,  # [On workflow call] Add software bill of materials to release (reusable)
         26915902,  # [On workflow call] Scan with Grype (reusable)
         25002877,  # [On PR] Dependency review
-        2393224,  #  [On PR] Tests
+        2393224,  # [On PR] Tests
     ],
     "opensafely-core/pipeline": [
         77090712,  # [Disabled] Pin pydantic
@@ -128,6 +128,6 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
         13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match
     ],
     "ebmdatalab/bennettbot": [
-        32719413,  #  Auto merge Dependabot PRs
+        32719413,  # Auto merge Dependabot PRs
     ],
 }

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -107,6 +107,7 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     ],
     "opensafely-core/airlock": [
         94122733,  # [Ignored on main, PR#277] Docs
+        122881950,  # [Awaiting PR approval to use on main] Update python dependencies
     ],
     "opensafely-core/cohort-extractor": [
         13520184,  # [On workflow dispatch] Check Trino version on EMIS and in docker-compose.yml match

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -132,4 +132,17 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     ],
 }
 
-WORKFLOWS_KNOWN_TO_FAIL = {}
+WORKFLOWS_KNOWN_TO_FAIL = {
+    "opensafely/documentation": [
+        25878886,  # Check links (expected to break, notifications handled elsewhere)
+    ],
+    "ebmdatalab/bennett.ox.ac.uk": [
+        42498719,  # Check links (expected to break, notifications handled elsewhere)
+    ],
+    "ebmdatalab/opensafely.org": [
+        26433647,  # Check links (expected to break, notifications handled elsewhere)
+    ],
+    "ebmdatalab/team-manual": [
+        31178226,  # Check links (expected to break, notifications handled elsewhere)
+    ],
+}

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -131,3 +131,5 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
         32719413,  # Auto merge Dependabot PRs
     ],
 }
+
+WORKFLOWS_KNOWN_TO_FAIL = {}

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -136,6 +136,12 @@ WORKFLOWS_KNOWN_TO_FAIL = {
     "opensafely/documentation": [
         25878886,  # Check links (expected to break, notifications handled elsewhere)
     ],
+    "opensafely-core/repo-template": [
+        108662507,  # Dependabot updates (currently broken and expected to be replaced)
+    ],
+    "opensafely-core/sqlrunner": [
+        108481072,  # Dependabot updates (currently broken and expected to be replaced)
+    ],
     "ebmdatalab/bennett.ox.ac.uk": [
         42498719,  # Check links (expected to break, notifications handled elsewhere)
     ],

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -220,7 +220,16 @@ def _summarise(header_text: str, locations: list[str], skip_successful: bool) ->
     unsorted = {}
     for location in locations:
         wf_conclusions = RepoWorkflowReporter(location).get_latest_conclusions()
-        if skip_successful and get_success_rate(list(wf_conclusions.values())) == 1:
+
+        # Skip reporting a failure that is already known
+        known_failure_ids = config.WORKFLOWS_KNOWN_TO_FAIL.get(location, [])
+        wf_conclusions = {
+            k: v
+            for k, v in wf_conclusions.items()
+            if v == "success" or k not in known_failure_ids
+        }
+
+        if skip_successful and all(c == "success" for c in wf_conclusions.values()):
             continue
         unsorted[location] = list(wf_conclusions.values())
 


### PR DESCRIPTION
- There are a couple of known failures (check links, dependabot updates) that are appearing daily and creating clutter
- Register these known failures in the `config.py` and hide them when creating summaries
- From the [Slack convo](https://bennettoxford.slack.com/archives/C01SE1WB6AW/p1728997930694689?thread_ts=1728994626.948159&cid=C01SE1WB6AW), still show them when the `target` is a specific repo, not a summary

It would be better to make this an optional configuration - explore in https://github.com/ebmdatalab/bennettbot/issues/618
Previous iteration of this PR: https://github.com/ebmdatalab/bennettbot/pull/617 