### PR TITLE
Unskip dependabot workflow for repo-template

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -136,12 +136,6 @@ WORKFLOWS_KNOWN_TO_FAIL = {
     "opensafely/documentation": [
         25878886,  # Check links (expected to break, notifications handled elsewhere)
     ],
-    "opensafely-core/repo-template": [
-        108662507,  # Dependabot updates (currently broken and expected to be replaced)
-    ],
-    "opensafely-core/sqlrunner": [
-        108481072,  # Dependabot updates (currently broken and expected to be replaced)
-    ],
     "ebmdatalab/bennett.ox.ac.uk": [
         42498719,  # Check links (expected to break, notifications handled elsewhere)
     ],


### PR DESCRIPTION
It now runs only for GithubActions, and is no longer an expected fail.