### PR TITLE
Call the API without creation timestamp filter if there are potential status updates

### DIFF
--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -338,7 +338,7 @@ def get_text_blocks_for_key(args) -> str:
     return json.dumps(blocks)
 
 
-def get_command_line_parser():  # pragma: no cover
+def get_command_line_parser():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(required=True)
 


### PR DESCRIPTION
Fixes #628.

Workflow statuses get updated since creation, and we want to show the most recent status. 
We dealt with changes from pending to completed statuses before but that method is insufficient to deal with manual reruns of workflows, which can lead to changes from one completed status to another (e.g. "failure" to "success").

If a workflow run has not succeeded at its time of creation, we consider there to be a possibility for a status update to have occurred since the last retrieval. In such cases, fetch the results without the `created` query parameter to make sure we are getting the latest statuses.