### PR TITLE
Do not notify tech support if a workflows reporting job fails

### DIFF
--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -196,6 +196,15 @@ def test_repo_only_as_target():
         mock__main.assert_called_once_with("opensafely-core", "airlock", False)
 
 
+def test_website_repo_as_target():
+    args = jobs.get_command_line_parser().parse_args(
+        "show --target http://bennett.ox.ac.uk".split()
+    )
+    with patch("workspace.workflows.jobs._main") as mock__main:
+        jobs.main(args)
+        mock__main.assert_called_once_with("ebmdatalab", "bennett.ox.ac.uk", False)
+
+
 def test_invalid_target():
     args = jobs.get_command_line_parser().parse_args(
         "show --target some/invalid/input".split()

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -200,9 +200,14 @@ def test_invalid_target():
     args = jobs.get_command_line_parser().parse_args(
         "show --target some/invalid/input".split()
     )
-
-    with pytest.raises(ValueError):
-        jobs.main(args)
+    blocks = json.loads(jobs.main(args))
+    assert blocks[0] == {
+        "type": "header",
+        "text": {
+            "type": "plain_text",
+            "text": "some/invalid/input was not recognised",
+        },
+    }
 
 
 @httpretty.activate(allow_net_connect=False)
@@ -689,6 +694,13 @@ def test_main_show_invalid_target():
             "text": {
                 "type": "plain_text",
                 "text": "invalid-org was not recognised",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Argument must be a known organisation or repo, or a repo given as [org/repo].",
             },
         },
         {

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -210,6 +210,34 @@ def test_invalid_target():
     }
 
 
+def test_catch_unhandled_error():
+    args = jobs.get_command_line_parser().parse_args(
+        "show --target some/invalid/input".split()
+    )
+    with patch(
+        "workspace.workflows.jobs.report_invalid_target",
+        return_value=None,
+        side_effect=Exception("Unknown error"),
+    ):
+        blocks = json.loads(jobs.main(args))
+    assert blocks == [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "An error occurred reporting workflows for some/invalid/input",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Unknown error",
+            },
+        },
+    ]
+
+
 @httpretty.activate(allow_net_connect=False)
 def test_get_workflows():
     # get_workflows is called in __init__, so create the instance here

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -372,5 +372,14 @@ def get_command_line_parser():
 
 
 if __name__ == "__main__":
-    args = get_command_line_parser().parse_args()
-    print(args.func(args))
+    try:
+        args = get_command_line_parser().parse_args()
+        print(args.func(args))
+    except Exception as e:
+        print(
+            json.dumps(
+                get_basic_header_and_text_blocks(
+                    header_text="An error occurred", texts=str(e)
+                )
+            )
+        )

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -278,20 +278,27 @@ def summarise_org(org, skip_successful) -> list:
 
 
 def main(args) -> str:
-    target = args.target.split("/")
-    if len(target) == 2:
-        org, repo = target
-    elif len(target) == 1:
-        if target[0] in config.REPOS.keys():  # Known repo
-            org, repo = config.REPOS[target[0]]["org"], target[0]
-        else:  # Assume org
-            org, repo = target[0], None
-    else:  # Invalid target format
-        return report_invalid_target(args.target)
+    try:
+        target = args.target.split("/")
+        if len(target) == 2:
+            org, repo = target
+        elif len(target) == 1:
+            if target[0] in config.REPOS.keys():  # Known repo
+                org, repo = config.REPOS[target[0]]["org"], target[0]
+            else:  # Assume org
+                org, repo = target[0], None
+        else:  # Invalid target format
+            return report_invalid_target(args.target)
 
-    # Org may be a shorthand
-    org = config.SHORTHANDS.get(org, org)
-    return _main(org, repo, args.skip_successful)
+        # Org may be a shorthand
+        org = config.SHORTHANDS.get(org, org)
+        return _main(org, repo, args.skip_successful)
+    except Exception as e:
+        blocks = get_basic_header_and_text_blocks(
+            header_text=f"An error occurred reporting workflows for {args.target}",
+            texts=str(e),
+        )
+        return json.dumps(blocks)
 
 
 def _main(org, repo, skip_successful=False) -> str:

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -42,10 +42,13 @@ def get_locations_for_org(org: str) -> list[str]:
     return [f"{org}/{repo}" for repo, v in config.REPOS.items() if v["org"] == org]
 
 
-def report_invalid_org(org) -> str:
+def report_invalid_target(target) -> str:
     blocks = get_basic_header_and_text_blocks(
-        header_text=f"{org} was not recognised",
-        texts=f"Run `@{settings.SLACK_APP_USERNAME} workflows help` to see the available organisations.",
+        header_text=f"{target} was not recognised",
+        texts=[
+            "Argument must be a known organisation or repo, or a repo given as [org/repo].",
+            f"Run `@{settings.SLACK_APP_USERNAME} workflows help` to see the available organisations.",
+        ],
     )
     return json.dumps(blocks)
 
@@ -284,9 +287,7 @@ def main(args) -> str:
         else:  # Assume org
             org, repo = target[0], None
     else:  # Invalid target format
-        raise ValueError(
-            "Argument must be a known organisation or repo, or a repo given as [org/repo]"
-        )
+        return report_invalid_target(args.target)
 
     # Org may be a shorthand
     org = config.SHORTHANDS.get(org, org)
@@ -313,7 +314,7 @@ def _main(org, repo, skip_successful=False) -> str:
         # Single repo usage: Report status for all workflows in a specified repo
         return RepoWorkflowReporter(f"{org}/{repo}").report()
     else:
-        return report_invalid_org(org)
+        return report_invalid_target(org)
 
 
 def get_blocks_for_custom_workflow_list(args):

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -279,7 +279,8 @@ def summarise_org(org, skip_successful) -> list:
 
 def main(args) -> str:
     try:
-        target = args.target.split("/")
+        # # Some repos are names of websites and slack prepends http:// to them
+        target = args.target.replace("http://", "").split("/")
         if len(target) == 2:
             org, repo = target
         elif len(target) == 1:


### PR DESCRIPTION
Fixes #633.

In the following scenarios, return a Slack message instead of falling over and notifying tech support
- Invalid input: Slack message about input format and valid organisations (`report_invalid_org` is now `report_invalid_target`)
- Unexpected error calling `workflows show` or `workflows show-failed`: Slack message containing the error and the `target` variable
- Unexpected error calling other `workflows` jobs: Slack message containing the error

Also fixes the problem that actually prompted the multiple failures this morning, which is the website repo names being prepended by "http://" by Slack 
 