### PR TITLE
Skip some Metrics repo PRs

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -130,6 +130,9 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     "ebmdatalab/bennettbot": [
         32719413,  # [On PR] Auto merge Dependabot PRs
     ],
+    "ebmdatalab/metrics": [
+        125350201,  # [On PR] Update python dependencies
+    ],
 }
 
 WORKFLOWS_KNOWN_TO_FAIL = {


### PR DESCRIPTION
The "Update python dependencies" workflow is currently broken and is in the process of being fixed (see [ticket](https://github.com/ebmdatalab/metrics/issues/250)), so we don't want to alert on it right now.