### PR TITLE
Revert "Skip some Metrics repo PRs"

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -130,9 +130,6 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     "ebmdatalab/bennettbot": [
         32719413,  # [On PR] Auto merge Dependabot PRs
     ],
-    "ebmdatalab/metrics": [
-        125350201,  # [On PR] Update python dependencies
-    ],
 }
 
 WORKFLOWS_KNOWN_TO_FAIL = {


### PR DESCRIPTION
This reverts commit da342bd7e91644905a2867cbb514d680bdde15b1.

The Metrics workflow is now working correctly and created PRs as expected, so we no longer need to ignore it.