### PR TITLE
Remove distutils

### DIFF
--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -1,6 +1,5 @@
 # list ubuntu packages needed in production, one per line
 openssh-client
 python3.12
-python3.12-distutils
 python3.12-venv
 sqlite3


### PR DESCRIPTION
distutils has been deprecated for some time, and was removed from 3.12's standard library ([PEP 632][]). Recently, python3.12-distutils was also removed from deadsnakes. Including it in docker/dependencies.txt breaks the build; removing it from this file seems to be harmless, probably because tools that depend upon it have already migrated to setuptools.

[PEP 632]: https://peps.python.org/pep-0632/