### PR TITLE
Pass in day_of_week argument

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -522,7 +522,7 @@ raw_config = {
                 "report_format": "blocks",
             },
             "daily": {
-                "run_args_template": "python jobs.py daily",
+                "run_args_template": "python jobs.py daily {day_of_week}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },


### PR DESCRIPTION
I tested this in Slack and while the weekly report works fine, the daily one isn't being passed the day_of_week argument. This PR should fix that.