### PR TITLE
Codespaces workflow: improve at risk calculation

### DIFF
--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -82,10 +82,11 @@ def main():
     if at_risk_codespaces:
         items = [
             (
-                f"`{cs.owner}` has a Codespace that they last used {cs.last_used_days_ago} days ago "
-                f"({cs.name}).\n"
-                f"Unpushed changes: {'Yes' if cs.has_unpushed else 'No'} | "
-                f"Uncommitted changes: {'Yes' if cs.has_uncommitted else 'No'}\n\n"
+                f"* `{cs.owner}` | "
+                f"last used {cs.last_used_days_ago} days ago | "
+                f"**id**: `{cs.name}` | "
+                f"**Uncommitted**: {'Yes' if cs.has_uncommitted else 'No'} | "
+                f"**Unpushed**: {'Yes' if cs.has_unpushed else 'No'}\n"
             )
             for cs in at_risk_codespaces
         ]

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -99,4 +99,6 @@ def main():
 
 
 if __name__ == "__main__":
-    print(main())
+    from pprint import pprint
+
+    pprint(json.loads(main()))

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -54,12 +54,13 @@ def fetch(url, key):
 def get_codespace(record):
     now = datetime.datetime.now(datetime.timezone.utc)
     last_used_at = datetime.datetime.fromisoformat(record["last_used_at"])
-    last_used_days_ago = (now - last_used_at).days
-    owner = record["owner"]["login"]
-    name = record["name"]
-    has_unpushed = record["git_status"]["has_unpushed_changes"]
-    has_uncommitted = record["git_status"]["has_uncommitted_changes"]
-    return Codespace(last_used_days_ago, owner, name, has_unpushed, has_uncommitted)
+    return Codespace(
+        last_used_days_ago=(now - last_used_at).days,
+        owner=record["owner"]["login"],
+        name=record["name"],
+        has_uncommitted=record["git_status"]["has_uncommitted_changes"],
+        has_unpushed=record["git_status"]["has_unpushed_changes"],
+    )
 
 
 def is_at_risk(codespace, threshold_in_days):

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -1,6 +1,12 @@
 """
 Queries the GitHub REST API "List Codespaces for the organization" endpoint
-and shows the Codespaces that are at risk of being deleted.
+and shows the Codespaces that are "at risk" of being deleted, defined as having
+uncommitted or unpushed changes and the retention period expiry being within
+some threshold.
+
+Refer to the codespaces playbook in the team manual for how this is used.
+As of 2025-01, that's located at:
+https://github.com/ebmdatalab/team-manual/blob/main/docs/tech-group/playbooks/codespaces.md
 """
 
 import collections
@@ -18,6 +24,8 @@ URL_PATTERN = "https://api.github.com/orgs/{org}/codespaces"
 # with "Codespaces" repository permissions set to "read" and "Organization codespaces"
 # organization permissions set to "read". For more information, see:
 # https://docs.github.com/en/rest/codespaces/organizations?apiVersion=2022-11-28#list-codespaces-for-the-organization
+# Someone with admin permissions on the organization needs to do this.
+# For the opensafely org, created PATs should be stored in BitWarden.
 TOKEN = os.environ["CODESPACES_GITHUB_API_TOKEN"]
 HEADERS = {
     "Accept": "application/vnd.github+json",
@@ -96,6 +104,7 @@ def is_at_risk(codespace, threshold_in_days):
 
 def main():
     org = "opensafely"
+    # Arbitrary threshold. Gives us a bit more than a week to respond.
     threshold_in_days = 10
 
     records = fetch(URL_PATTERN.format(org=org), "codespaces")


### PR DESCRIPTION
Towards #667.

Now the workflow reports codespaces with unsaved changes approaching their defined retention expiry period, rather than assuming 30 days which may not be accurate.

I will raise a separate PR in the team-manual repo for the playbook updates. I've included extra info in the message to help with this (expiry datetime, repo, retention period).

I've addressed most of the issues that were outstanding from review of the original implementation of this workflow. I didn't find a good way to collapse or thread the message if it's long. The Slack API can handle threaded messages but BennettBot isn't set up for it and it seemed too much work for this PR. I've made the message a bit more compact.

There were no automated tests of this workflow. I think the logic of extracting data from the records and calculating the threshold are simple enough that observing the results manually could be good enough. Let me know if you think we should have some.

I have tested locally by running the command at the CLI to see the output:
```
~/bennettbot$ CODESPACES_GITHUB_API_TOKEN=XXX PYTHONPATH=. .venv/bin/python3 workspace/codespaces/codespaces.py
[{'text': {'text': 'Codespaces at risk report', 'type': 'plain_text'},
  'type': 'header'},
 {'text': {'text': '`opensafely` Codespaces at risk of deletion (expire within '
                   '10 days):\n'
                   '\n'
                   '* `george-w-jenkins` | on Sun, Jan 19 at 12:31 (10 days) | '
                   '**repo**: `sodium-valproate-prescribing` | **id**: '
                   '`bookish-orbit-p5g5wq7ggqp3rpq7` | **Retention**: 30 days '
                   '| **Uncommitted**: Yes | **Unpushed**: Yes\n'
                   '* `marrpesce` | on Sun, Jan 19 at 13:16 (10 days) | '
                   '**repo**: `covid-vaccine-history` | **id**: '
                   '`zany-space-xylophone-v5j5r5w77v4cxx9w` | **Retention**: '
                   '30 days | **Uncommitted**: Yes | **Unpushed**: Yes\n',
           'type': 'mrkdwn'},
  'type': 'section'}]

```
`CODESPACES_GITHUB_API_TOKEN` can be found in BitWarden.

I have not tried running the command in the bot test workspace because the overhead of understanding how to make the bot work from a branch doesn't seem worth the effort. If the PR is pushed I can run the command manually in #tech-noise and observe that it's behaving. There's a week until it's due to run again "for real" and this message isn't that important so it doesn't seem risky to take this approach.