### PR TITLE
Skip reporting missing workflows in summaries

### DIFF
--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -227,12 +227,12 @@ def _summarise(header_text: str, locations: list[str], skip_successful: bool) ->
     for location in locations:
         wf_conclusions = RepoWorkflowReporter(location).get_latest_conclusions()
 
-        # Skip reporting a failure that is already known
+        # Skip reporting missing workflows and failures that are already known
         known_failure_ids = config.WORKFLOWS_KNOWN_TO_FAIL.get(location, [])
         wf_conclusions = {
             k: v
             for k, v in wf_conclusions.items()
-            if v == "success" or k not in known_failure_ids
+            if v == "success" or (k not in known_failure_ids and v != "missing")
         }
 
         if len(wf_conclusions) == 0:


### PR DESCRIPTION
[Slack thread](https://bennettoxford.slack.com/archives/C63UXGB8E/p1736229649367949)

Skip reporting workflows being missing in summary reports. The behaviour for repo reports remains unchanged for now.