### PR TITLE
Codespaces report: hotfix for output

### DIFF
--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -152,6 +152,4 @@ def main():
 
 
 if __name__ == "__main__":
-    from pprint import pprint
-
-    pprint(json.loads(main()))
+    print(main())

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -133,7 +133,7 @@ def main():
             (
                 f"* `{cs.owner}` | "
                 f"on {cs.retention_expires_at:%a, %b %d at %H:%M} "
-                f"({cs.remaining_retention_period_days} days) | "
+                f"({'<1 day' if not cs.remaining_retention_period_days else str(cs.remaining_retention_period_days) + ' days'}) | "
                 f"**repo**: `{cs.repo}` | "
                 f"**id**: `{cs.name}` | "
                 f"**Retention**: {cs.retention_period_days} days | "


### PR DESCRIPTION
Revert to using `print` in output and no `json.loads`. 

Since https://github.com/ebmdatalab/bennettbot/commit/c086fa0d12aa3c879b9493768c8d4b659ee944ed was pushed, the bot has stopped printing output when the command is run. From looking at the logged output, I think this is the culprit: it can't interpret the prettified text as it expects for display in Slack.